### PR TITLE
Fix issue raised by workflow step SetNextDevVersion for Maven projects in subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TBD
 
 
+## [3.1.0]
+<!-- !!! Align version in badge URLs as well !!! -->
+[![3.1.0 Badge](https://img.shields.io/nexus/r/io.github.mavenplugins/unleash-scm-provider-git?server=https://s01.oss.sonatype.org&label=Maven%20Central&queryOpt=:v=3.1.0)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-scm-provider-git/3.1.0)
+
+### Summary
+- Fix issue raised by workflow step `SetNextDevVersion` for Git SCM projects. - #6<br>
+
+### 🐛 Fixes
+- Fix issue raised by workflow step `SetNextDevVersion` for Git SCM projects. - #6<br>
+  If the Maven project base dir is within a sub folder of the git checkout directory,
+  then the next dev modified POMs did not get recognized as changed files to be commited.<br>
+  ❗👉 Requires `unleash-scm-provider-api` version `3.2.0` or later❗
+
+### Updates
+- pom.xml:
+  - update dependency `unleash-scm-provider-api` to version `3.2.0`
+- ScmProviderGit.java:
+  - consider relative working dir parent to Git work tree for files added to commit
+
+
 ## [3.0.1]
 <!-- !!! Align version in badge URLs as well !!! -->
 [![3.0.1 Badge](https://img.shields.io/nexus/r/io.github.mavenplugins/unleash-scm-provider-git?server=https://s01.oss.sonatype.org&label=Maven%20Central&queryOpt=:v=3.0.1)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-scm-provider-git/3.0.1)
@@ -167,7 +187,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This is just a dummy placeholder to make the parser of GHCICD/release-notes-from-changelog@v1 happy!
 -->
 
-[Unreleased]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v3.0.1..HEAD
+[Unreleased]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v3.1.0..HEAD
+[3.1.0]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v3.0.1..v3.1.0
 [3.0.1]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v3.0.0..v3.0.1
 [3.0.0]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v2.4.0..v3.0.0
 [2.4.0]: https://github.com/mavenplugins/unleash-scm-provider-git/compare/v2.3.0..v2.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>org-parent</artifactId>
-    <version>5</version>
+    <version>8</version>
     <relativePath/>
   </parent>
 
   <artifactId>unleash-scm-provider-git</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <name>Unleash SCM Provider Git</name>
   <description>The Git SCM provider for the Unleash Maven Plugin.</description>
@@ -50,9 +50,9 @@
     <version.java>1.8</version.java>
     <javadoc.doclint>none</javadoc.doclint>
     <!-- UNLEASH -->
-    <version.unleash-maven-plugin>3.0.1</version.unleash-maven-plugin>
+    <version.unleash-maven-plugin>3.2.0</version.unleash-maven-plugin>
     <!-- Resolve chicken/egg unleash by defining specific unleash commandline goal: -->
-    <version.unleash-maven-plugin.perform>3.0.0</version.unleash-maven-plugin.perform>
+    <version.unleash-maven-plugin.perform>3.2.0</version.unleash-maven-plugin.perform>
     <unleash.goal>perform</unleash.goal>
     <!-- This is considered by the reusable GH unleash action: -->
     <unleash.cmdline.goal>${groupId.unleash-maven-plugin}:${artifactId.unleash-maven-plugin}:${version.unleash-maven-plugin.perform}:${unleash.goal}</unleash.cmdline.goal>


### PR DESCRIPTION
- Fix issue raised by workflow step `SetNextDevVersion` for Git SCM projects.<br>
  If the Maven project base dir is within a sub folder of the git checkout directory,
  then the next dev modified POMs did not get recognized as changed files to be commited.<br>
  ❗👉 Requires `unleash-scm-provider-api` version `3.2.0` or later❗