### PR TITLE
Improve dependabot to ignore jgit versions >= 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     # ignore any artifacts to comply with jgit version - those are managed manually!
     - dependency-name: "com.google.code.gson:*"
     - dependency-name: "org.apache.sshd:*"
+    # ignore jgit versions >= 6.*
+    - dependency-name: "org.eclipse.jgit:*"
+      versions: ["[6.0,)"]
     # ignore slf4j-api - will be managed manually
     - dependency-name: "org.slf4j:slf4j-api"
 


### PR DESCRIPTION
- update .github/dependabot.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency configuration to exclude certain package versions from automated updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->