### PR TITLE
Bump apache-sshd from 2.14.0 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <!-- !!! version.gson must be COMPLIANT with version.jgit !!! -->
     <version.gson>2.8.9</version.gson>
     <!-- !!! version.apache-sshd version must be COMPLIANT with version.jgit !!! -->
-    <version.apache-sshd>2.14.0</version.apache-sshd>
+    <version.apache-sshd>2.16.0</version.apache-sshd>
     <version.slf4j>1.7.36</version.slf4j>
     <!-- TEST -->
     <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
- pom.xml:
  - bump version.apache-sshd from 2.14.0 to 2.16.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache SSHD library dependency to version 2.16.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->